### PR TITLE
add sky-500 to use in footer

### DIFF
--- a/components/common/Footer.tsx
+++ b/components/common/Footer.tsx
@@ -62,7 +62,7 @@ const LINKS = [
 /** Footer */
 const Footer: FC = () => {
   return (
-    <footer className="w-full bg-gradient-to-r from-blue to-sky-400">
+    <footer className="w-full bg-gradient-to-r from-blue to-sky-500">
       <div className="content relative z-10 flex flex-col items-center gap-20 mx-auto pt-14 pb-6">
         <div className="flex justify-center items-stretch gap-20">
           {/* Logo, social media links */}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -39,6 +39,7 @@ module.exports = {
         200: "#BDDEFF",
         300: "#99CEFF",
         400: "#7EB9F0",
+        500: "#4498ED"
       },
 
       // SECONDARY


### PR DESCRIPTION
Footer was using incorrect colour, resulting in poor text contrast - added to config and Figma styles

Before:

![](https://user-images.githubusercontent.com/55633069/149703632-39782286-5313-4b3c-9c09-2a1b4f83c44d.png)

After:

![](https://user-images.githubusercontent.com/55633069/149703547-e2d532f6-8659-4ad0-8ded-21c4a8f5ee09.png)