### PR TITLE
Fix application banner term

### DIFF
--- a/components/common/NavBar.tsx
+++ b/components/common/NavBar.tsx
@@ -20,7 +20,7 @@ const Navbar: FC = () => {
         {APPLICATION_IS_LIVE && (
           <Link href={APPLICATION_LINK}>
             <a className="block w-full text-center px-4 py-1 bg-charcoal-0 font-poppins">
-              Applications to join the Winter 2022 team are now open,{" "}
+              Applications to join the Spring 2022 team are now open,{" "}
               <span className="underline">apply here</span>! 🎉
             </a>
           </Link>


### PR DESCRIPTION
Application banner should say "Spring 2022" instead of "Winter 2022"

Fixed:
![image](https://user-images.githubusercontent.com/30249230/155871524-ab5b9edc-e709-421a-9cc9-1d0e792ac563.png)
