### PR TITLE
Fix VP Eng roles

### DIFF
--- a/constants/members.json
+++ b/constants/members.json
@@ -1653,14 +1653,14 @@
     },
     {
       "name": "Prannoy Lal",
-      "role": "vp eng",
+      "role": "vp engineering",
       "term": 1225,
       "teams": ["executive"],
       "img": "https://firebasestorage.googleapis.com/v0/b/uw-blueprint.appspot.com/o/img%2Ffall2020headshots%2FDev_PrannoyLal.jpg?alt=media&token=7d342bc9-d100-4cb3-8075-a8e762c238a9"
     },
     {
       "name": "Tayef Shah",
-      "role": "vp eng",
+      "role": "vp engineering",
       "term": 1225,
       "teams": ["executive"],
       "img": "https://firebasestorage.googleapis.com/v0/b/uw-blueprint.appspot.com/o/img%2Ffall2020headshots%2FDev_TayefShah.jpeg?alt=media&token=58d2053d-cee9-4e05-9ac5-175b800d4c13"


### PR DESCRIPTION
Reason: in components/members/utils.ts, we have a roleType map which is used to assign priorities to the roles. The role for VPE is "vp engineering" not "vp eng" and as a result Tayef/Prannoy showed up at the end of the e-team section when they should be near the top. Also it is good to have consistent naming conventions for roles on the website.