### PR TITLE
Implement Role Specific Questions Component

### DIFF
--- a/components/apply/AppForm.tsx
+++ b/components/apply/AppForm.tsx
@@ -23,11 +23,11 @@ const AppForm: FC = () => {
         onSecondChoiceChange={setSecondChoice}
       />
       <ShortAnswers />
-      <SelfIdentificationForm />
       <RoleSpecificQuestions
         firstChoice={firstChoice}
         secondChoice={secondChoice}
       />
+      <SelfIdentificationForm />
     </section>
   );
 };

--- a/components/apply/AppForm.tsx
+++ b/components/apply/AppForm.tsx
@@ -1,6 +1,7 @@
 import { FC, useState } from "react";
 import BasicInfo from "./BasicInfo";
 import PositionPreference from "./PositionPreference";
+import RoleSpecificQuestions from "./RoleSpecificQuestions";
 import ShortAnswers from "./ShortAnswers";
 import SelfIdentificationForm from "./SelfIdentification";
 import InfoText from "@components/apply/InfoText";
@@ -23,6 +24,10 @@ const AppForm: FC = () => {
       />
       <ShortAnswers />
       <SelfIdentificationForm />
+      <RoleSpecificQuestions
+        firstChoice={firstChoice}
+        secondChoice={secondChoice}
+      />
     </section>
   );
 };

--- a/components/apply/RoleSpecificQuestions.tsx
+++ b/components/apply/RoleSpecificQuestions.tsx
@@ -22,9 +22,6 @@ const RoleSpecificQuestions: FC<Props> = ({
   return (
     <div className="grid gap-3 my-8">
       <h4 className="text-blue-100">Role Specific Questions</h4>
-      <p className="text-charcoal-500 mb-4">
-        todo: what is the text here supposed to be lol
-      </p>
       <div className="grid gap-6">
         {questions.map((question, i) => (
           <TextAreaInput

--- a/components/apply/RoleSpecificQuestions.tsx
+++ b/components/apply/RoleSpecificQuestions.tsx
@@ -1,0 +1,42 @@
+import { FC } from "react";
+import data from "@constants/role-specific-questions.json";
+import TextAreaInput from "@components/common/TextAreaInput";
+
+type Props = {
+  firstChoice: string;
+  secondChoice: string;
+};
+
+const RoleSpecificQuestions: FC<Props> = ({
+  firstChoice,
+  secondChoice,
+}: Props) => {
+  const questions = (
+    (data[firstChoice as keyof typeof data] ?? []) as string[]
+  ).concat((data[secondChoice as keyof typeof data] ?? []) as string[]);
+
+  if (!questions.length) {
+    return <></>;
+  }
+
+  return (
+    <div className="grid gap-3 my-8">
+      <h4 className="text-blue-100">Role Specific Questions</h4>
+      <p className="text-charcoal-500 mb-4">
+        todo: what is the text here supposed to be lol
+      </p>
+      <div className="grid gap-6">
+        {questions.map((question, i) => (
+          <TextAreaInput
+            id={`roleSpecific${i + 1}`}
+            key={`roleSpecific${i + 1}`}
+            labelText={question}
+            required
+          />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default RoleSpecificQuestions;

--- a/constants/role-specific-questions.json
+++ b/constants/role-specific-questions.json
@@ -1,0 +1,44 @@
+{
+  "1": [
+    "Which areas of a project are you interested in working in (frontend, backend, fullstack, mobile, etc.)?* (Project Developer)",
+    "Tell us about a challenging technical problem that you’ve worked on in the past and how you solved it.* (Project Developer)"
+  ],
+  "2": [
+    "Send us a link to your portfolio or a project you've worked on. If you do not have a link, please tell us about a project below. Describe the process and what you learned from it!* (Product Designer)"
+  ],
+  "3": [
+    "What is your favourite product?* (Product Manager)"
+  ],
+  "4": [
+    "Tell us about a challenging technical problem that you’ve worked on in the past and how you solved it.* (Project Lead)"
+  ],
+  "5": [
+    "Describe the type of research methods you prefer to use. What would you consider to be your main methods of expertise?* (User Experience Researcher)"
+  ],
+  "6": [
+    "What do you see as the purposes of content within the user experience of an app?* (Content Strategist)"
+  ],
+  "7": [
+    "Send us a link to your portfolio or a project you've worked on. If you do not have a link, please tell us about a project below. Describe the process and what you learned from it!* (Graphic Designer)"
+  ],
+  "8": [
+    "Consider this hypothetical scenario: Blueprint is thinking of creating a standardized code repository for new projects to build off of. This idea has both supporters and detractors among the project leads. In bullet points, explain how you would build alignment among developers. Please state any assumptions or details as necessary.* (VP Engineering)"
+  ],
+  "9": [],
+  "10": [],
+  "11": [
+    "What's a cool idea you think Blueprint should do to elevate our current branding and image in the community?* (VP Communications)"
+  ],
+  "12": [
+    "How would you pitch to external organizations for sponsorship?* (VP Finance & Operations)"
+  ],
+  "13": [
+    "How do you know whether a non-profit has a goal that resonates with Blueprint?* (VP Project Scoping)"
+  ],
+  "14": [
+    "What's a cool new event you think Blueprint should do and how does it align with Blueprint's mission?* (VP External)"
+  ],
+  "15": [
+    "What would an ideal member experience look like to you?* (VP Internal)"
+  ]
+}


### PR DESCRIPTION
<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description
- Created role specific questions in `RoleSpecificQuestions.tsx` component
- Takes in first and second choice from as props, then maps them to a JSON object of role specific questions for each role
- Section only displays if there exist questions for whatever is selected + if at least one of first/second choice is selected
- Used `TextAreaInput` component for the text area

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test
1. Run locally and go to `http://localhost:3000/apply`
2. Confirm that nothing appears if no position preferences are selected or if there are no questions for those role(s) (VP Talent, VP Product)
3. Confirm that questions appear if position preferences are selected and those roles have role specific questions. First choice questions should be shown first then second choice questions. Also, the section header should show above the questions.

![image](https://user-images.githubusercontent.com/16995909/197124151-ff9b202d-f2c3-44e2-89c5-97db79321cc9.png)


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?
- Question text + styling correctness

### Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] I have run the linter
- [x] I have requested a review from other devs who have background knowledge on this PR or who will be building on top of this PR
