### PR TITLE
Create readOnly modes for common inputs

### DIFF
--- a/components/apply/BasicInfo.tsx
+++ b/components/apply/BasicInfo.tsx
@@ -102,6 +102,7 @@ const BasicInfo: FC<Props> = ({ values }: Props) => {
         <SelectInput
           id="heardFrom"
           labelText="Where did you hear about us?"
+          value={values.heardFrom}
           required
           options={SELECT_SOURCES}
         />
@@ -109,6 +110,7 @@ const BasicInfo: FC<Props> = ({ values }: Props) => {
         <SelectInput
           id="timesApplied"
           labelText="How many times have you applied to Blueprint in the past?"
+          value={values.timesApplied}
           required
           options={SELECT_APPNUM}
         />
@@ -116,6 +118,7 @@ const BasicInfo: FC<Props> = ({ values }: Props) => {
         <SelectInput
           id="pronouns"
           labelText="What are your preferred pronouns?"
+          value={values.pronouns}
           options={SELECT_PRONOUNS}
           required={false}
         />
@@ -155,6 +158,7 @@ const BasicInfo: FC<Props> = ({ values }: Props) => {
         <SelectInput
           id="locationPreference"
           labelText="What is your preferred working location?"
+          value={values.locationPreference}
           options={WORKING_LOCATIONS}
           required={true}
         />

--- a/components/apply/PositionPreference.tsx
+++ b/components/apply/PositionPreference.tsx
@@ -38,12 +38,14 @@ const PositionPreference: FC<Props> = ({ values, memberRoles }: Props) => {
         <SelectInput
           id="firstChoiceRole"
           labelText="What is your first choice role?"
+          value={values.firstChoiceRole}
           options={memberRoles}
           required
         />
         <SelectInput
           id="secondChoiceRole"
           labelText="Optional: What is your second choice role? (only select if you want to be considered for this role)"
+          value={values.secondChoiceRole}
           options={secondChoiceRoles}
           required={false}
         />

--- a/components/apply/SelfIdentification.tsx
+++ b/components/apply/SelfIdentification.tsx
@@ -58,6 +58,7 @@ const SelfIdentificationForm: FC<Props> = ({ values }: Props) => {
         <SelectInput
           id="gender"
           labelText={"What is your gender identity?"}
+          value={values.gender}
           options={GENDER_IDENTITIES}
           required={false}
         />
@@ -71,6 +72,7 @@ const SelfIdentificationForm: FC<Props> = ({ values }: Props) => {
         <SelectInput
           id="ethnicity"
           labelText="What ethnicity do you identify with?"
+          value={values.ethnicity}
           options={ETHNICITIES}
           required={false}
         />

--- a/components/common/SelectInput.tsx
+++ b/components/common/SelectInput.tsx
@@ -4,11 +4,20 @@ import { FC } from "react";
 type Props = {
   readonly id: string;
   readonly labelText?: string;
+  readonly value?: string;
   readonly options: string[];
   readonly required: boolean;
+  readonly readOnly?: boolean;
 };
 
-const SelectInput: FC<Props> = ({ id, labelText, options, required }) => {
+const SelectInput: FC<Props> = ({
+  id,
+  labelText,
+  value,
+  options,
+  required,
+  readOnly,
+}) => {
   return (
     <div className="flex flex-col space-y-2">
       {labelText && (
@@ -17,23 +26,27 @@ const SelectInput: FC<Props> = ({ id, labelText, options, required }) => {
           {required && <span className="text-pink-500">*</span>}
         </label>
       )}
-      <Field
-        as="select"
-        id={id}
-        name={id}
-        className="border-l-charcoal-300 text-charcoal-600 border border-charcoal-300 rounded-md px-4 py-3 border-l-4 focus:outline-none focus:ring-1 focus:ring-blue-100 focus:border-blue-100"
-        style={{ minHeight: "50px" }}
-        required={required}
-      >
-        <option value="" disabled>
-          Select an option
-        </option>
-        {options.map((value) => (
-          <option key={value} value={value}>
-            {value}
+      {readOnly ? (
+        <div className="text-charcoal-500">{value}</div>
+      ) : (
+        <Field
+          as="select"
+          id={id}
+          name={id}
+          className="border-l-charcoal-300 text-charcoal-600 border border-charcoal-300 rounded-md px-4 py-3 border-l-4 focus:outline-none focus:ring-1 focus:ring-blue-100 focus:border-blue-100"
+          style={{ minHeight: "50px" }}
+          required={required}
+        >
+          <option value="" disabled>
+            Select an option
           </option>
-        ))}
-      </Field>
+          {options.map((value) => (
+            <option key={value} value={value}>
+              {value}
+            </option>
+          ))}
+        </Field>
+      )}
     </div>
   );
 };

--- a/components/common/TextAreaInput.tsx
+++ b/components/common/TextAreaInput.tsx
@@ -8,6 +8,7 @@ type Props = {
   readonly placeholder?: string;
   readonly required?: boolean;
   readonly maxLength?: number;
+  readonly readOnly?: boolean;
 };
 
 const TextAreaInput: FC<Props> = ({
@@ -17,6 +18,7 @@ const TextAreaInput: FC<Props> = ({
   placeholder,
   required,
   maxLength,
+  readOnly,
 }) => {
   return (
     <div className="flex flex-col space-y-2">
@@ -26,24 +28,30 @@ const TextAreaInput: FC<Props> = ({
           {required && <span className="text-pink-500">*</span>}
         </label>
       )}
-      <Field
-        as="textarea"
-        id={id}
-        name={id}
-        className={
-          (required && value == ""
-            ? "border-l-pink-500 "
-            : "border-l-charcoal-300 ") +
-          "text-charcoal-600 border border-charcoal-300 rounded-md px-4 py-3 border-l-4 focus:outline-none focus:ring-1 focus:ring-blue-100 focus:border-blue-100"
-        }
-        style={{ resize: "none" }}
-        placeholder={placeholder}
-        required={required}
-        rows={4}
-        maxLength={maxLength}
-      />
+      {readOnly ? (
+        <div className="border-l-charcoal-300 border-l-4 pl-3 ml-1 text-charcoal-500">
+          {value}
+        </div>
+      ) : (
+        <Field
+          as="textarea"
+          id={id}
+          name={id}
+          className={
+            (required && value == ""
+              ? "border-l-pink-500 "
+              : "border-l-charcoal-300 ") +
+            "text-charcoal-600 border border-charcoal-300 rounded-md px-4 py-3 border-l-4 focus:outline-none focus:ring-1 focus:ring-blue-100 focus:border-blue-100"
+          }
+          style={{ resize: "none" }}
+          placeholder={placeholder}
+          required={required}
+          rows={4}
+          maxLength={maxLength}
+        />
+      )}
 
-      {maxLength && value && (
+      {maxLength && value && !readOnly && (
         <span className="text-charcoal-500 text-sm">
           {value.length} / {maxLength} characters
         </span>

--- a/components/common/TextInput.tsx
+++ b/components/common/TextInput.tsx
@@ -9,6 +9,7 @@ type Props = {
   readonly regexMatch?: RegExp;
   readonly errorMessage?: string;
   readonly required?: boolean;
+  readonly readOnly?: boolean;
 };
 
 const TextInput: FC<Props> = ({
@@ -19,6 +20,7 @@ const TextInput: FC<Props> = ({
   regexMatch,
   errorMessage,
   required,
+  readOnly,
 }) => {
   const [error, setError] = useState<boolean>(false);
 
@@ -40,19 +42,23 @@ const TextInput: FC<Props> = ({
           {required && <span className="text-pink-500">*</span>}
         </label>
       )}
-      <Field
-        id={id}
-        name={id}
-        className={
-          ((required && value == "") || error
-            ? "border-l-pink-500 "
-            : "border-l-charcoal-300 ") +
-          "text-charcoal-600 border border-charcoal-300 rounded-md px-4 py-3 border-l-4 focus:outline-none focus:ring-1 focus:ring-blue-100 focus:border-blue-100"
-        }
-        value={value || ""}
-        placeholder={placeholder}
-        required={required}
-      />
+      {readOnly ? (
+        <div className="text-charcoal-500">{value}</div>
+      ) : (
+        <Field
+          id={id}
+          name={id}
+          className={
+            ((required && value == "") || error
+              ? "border-l-pink-500 "
+              : "border-l-charcoal-300 ") +
+            "text-charcoal-600 border border-charcoal-300 rounded-md px-4 py-3 border-l-4 focus:outline-none focus:ring-1 focus:ring-blue-100 focus:border-blue-100"
+          }
+          value={value || ""}
+          placeholder={placeholder}
+          required={required}
+        />
+      )}
       {required && value == "" && (
         <span className="text-pink-500 text-sm">* Required</span>
       )}


### PR DESCRIPTION
<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- Added `readOnly` props to `SelectInput`, `TextInput`, and `TextAreaInput` - this will be used for the rendering of the application details page

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. N/A

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

- N/A

### Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] I have run the linter
- [x] I have requested a review from other devs who have background knowledge on this PR or who will be building on top of this PR
