### PR TITLE
Add read only to SA and role question sections

### DIFF
--- a/components/apply/AppForm.tsx
+++ b/components/apply/AppForm.tsx
@@ -233,10 +233,15 @@ const AppForm: FC<Props> = ({ readOnly = false }) => {
               values={values}
               memberRoles={roleSpecificQuestions.map(({ role }) => role)}
             />
-            <ShortAnswers values={values} questions={shortAnswerQuestions} />
+            <ShortAnswers
+              values={values}
+              questions={shortAnswerQuestions}
+              readOnly={readOnly}
+            />
             <RoleSpecificQuestions
               values={values}
               questions={roleSpecificQuestions}
+              readOnly={readOnly}
             />
             {!readOnly && <SelfIdentificationForm values={values} />}
             {!readOnly && (

--- a/components/apply/RoleSpecificQuestions.tsx
+++ b/components/apply/RoleSpecificQuestions.tsx
@@ -5,7 +5,7 @@ import { AppFormValues, RoleSpecificQuestion } from "./AppForm";
 type Props = {
   values: AppFormValues;
   questions: RoleSpecificQuestion[];
-  readOnly?: boolean;
+  readOnly: boolean;
 };
 
 const RoleSpecificQuestions: FC<Props> = ({

--- a/components/apply/RoleSpecificQuestions.tsx
+++ b/components/apply/RoleSpecificQuestions.tsx
@@ -5,9 +5,14 @@ import { AppFormValues, RoleSpecificQuestion } from "./AppForm";
 type Props = {
   values: AppFormValues;
   questions: RoleSpecificQuestion[];
+  readOnly?: boolean;
 };
 
-const RoleSpecificQuestions: FC<Props> = ({ values, questions }: Props) => {
+const RoleSpecificQuestions: FC<Props> = ({
+  values,
+  questions,
+  readOnly,
+}: Props) => {
   if (!questions.length) {
     return <></>;
   }
@@ -22,10 +27,12 @@ const RoleSpecificQuestions: FC<Props> = ({ values, questions }: Props) => {
   return questionsToRender.length > 0 ? (
     <div className="grid gap-3 mb-12">
       <h4 className="text-blue-100">Role Specific Questions</h4>
-      <p className="text-charcoal-500 mb-4">
-        Please answer the following questions in a few sentences where
-        applicable. (max length: 1000 characters)
-      </p>
+      {!readOnly && (
+        <p className="text-charcoal-500 mb-4">
+          Please answer the following questions in a few sentences where
+          applicable. (max length: 1000 characters)
+        </p>
+      )}
       <div className="grid gap-6">
         {questions.map((roleSpecificQuestion, index) => {
           if (
@@ -44,6 +51,7 @@ const RoleSpecificQuestions: FC<Props> = ({ values, questions }: Props) => {
                 }
                 maxLength={question.maxLength}
                 required
+                readOnly={readOnly}
               />
             ));
           }

--- a/components/apply/ShortAnswers.tsx
+++ b/components/apply/ShortAnswers.tsx
@@ -5,16 +5,19 @@ import { AppFormValues, ShortAnswerQuestion } from "./AppForm";
 type Props = {
   values: AppFormValues;
   questions: ShortAnswerQuestion[];
+  readOnly?: boolean;
 };
 
-const ShortAnswers: FC<Props> = ({ questions, values }: Props) => {
+const ShortAnswers: FC<Props> = ({ values, questions, readOnly }: Props) => {
   return (
     <section className="grid gap-3 mb-12">
       <h4 className="text-blue-100">Short Answers</h4>
-      <p className="text-charcoal-500 mb-4">
-        Please answer the following questions in a few sentences. (max length:
-        1000 characters)
-      </p>
+      {!readOnly && (
+        <p className="text-charcoal-500 mb-4">
+          Please answer the following questions in a few sentences. (max length:
+          1000 characters)
+        </p>
+      )}
       <div className="grid gap-6">
         {questions.map((question, i) => (
           <TextAreaInput
@@ -24,6 +27,7 @@ const ShortAnswers: FC<Props> = ({ questions, values }: Props) => {
             value={values.shortAnswerQuestions[i].response}
             maxLength={question.maxLength}
             required
+            readOnly={readOnly}
           />
         ))}
       </div>

--- a/components/apply/ShortAnswers.tsx
+++ b/components/apply/ShortAnswers.tsx
@@ -5,7 +5,7 @@ import { AppFormValues, ShortAnswerQuestion } from "./AppForm";
 type Props = {
   values: AppFormValues;
   questions: ShortAnswerQuestion[];
-  readOnly?: boolean;
+  readOnly: boolean;
 };
 
 const ShortAnswers: FC<Props> = ({ values, questions, readOnly }: Props) => {


### PR DESCRIPTION
<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- Added `readOnly` as prop to `ShortAnswers.tsx` and `RoleSpecificQuestions.tsx` components

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. Go to `http://localhost:3000/apply`
2. Add `readOnly` prop to section components
3. Scroll down to check they are now read only on the form

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

- Code correctness

### Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] I have run the linter
- [x] I have requested a review from other devs who have background knowledge on this PR or who will be building on top of this PR
