### PR TITLE
Add read only to Basic Info application section

### DIFF
--- a/components/apply/AppForm.tsx
+++ b/components/apply/AppForm.tsx
@@ -228,7 +228,7 @@ const AppForm: FC<Props> = ({ readOnly = false }) => {
           <section className="container max-w-4xl px-4 mx-auto mt-44 mb-12 md:mt-40 md:mb-16">
             <h2 className="text-blue-100 mb-8">Student Application</h2>
             <InfoText deadline={APPLICATION_CLOSE_DATETIME} />
-            <BasicInfo values={values} readOnly={true} />
+            <BasicInfo values={values} readOnly={readOnly} />
             <PositionPreference
               values={values}
               memberRoles={roleSpecificQuestions.map(({ role }) => role)}

--- a/components/apply/AppForm.tsx
+++ b/components/apply/AppForm.tsx
@@ -228,7 +228,7 @@ const AppForm: FC<Props> = ({ readOnly = false }) => {
           <section className="container max-w-4xl px-4 mx-auto mt-44 mb-12 md:mt-40 md:mb-16">
             <h2 className="text-blue-100 mb-8">Student Application</h2>
             <InfoText deadline={APPLICATION_CLOSE_DATETIME} />
-            <BasicInfo values={values} />
+            <BasicInfo values={values} readOnly={true} />
             <PositionPreference
               values={values}
               memberRoles={roleSpecificQuestions.map(({ role }) => role)}

--- a/components/apply/BasicInfo.tsx
+++ b/components/apply/BasicInfo.tsx
@@ -6,9 +6,10 @@ import { AppFormValues } from "./AppForm";
 
 type Props = {
   values: AppFormValues;
+  readOnly: boolean;
 };
 
-const BasicInfo: FC<Props> = ({ values }: Props) => {
+const BasicInfo: FC<Props> = ({ values, readOnly }: Props) => {
   const formikProps = useFormikContext();
 
   const SELECT_SOURCES = [
@@ -45,6 +46,7 @@ const BasicInfo: FC<Props> = ({ values }: Props) => {
           labelText="First Name"
           placeholder="e.g. John, Jane"
           value={values.firstName}
+          readOnly={readOnly}
           required
         />
         <TextInput
@@ -52,6 +54,7 @@ const BasicInfo: FC<Props> = ({ values }: Props) => {
           labelText="Last Name"
           placeholder="e.g. Smith"
           value={values.lastName}
+          readOnly={readOnly}
           required
         />
         <TextInput
@@ -61,6 +64,7 @@ const BasicInfo: FC<Props> = ({ values }: Props) => {
           value={values.email}
           regexMatch={/^\S+@\S+\.\S+$/}
           errorMessage="Please enter a valid email address"
+          readOnly={readOnly}
           required
         />
         <br className="md:block hidden" />
@@ -69,6 +73,7 @@ const BasicInfo: FC<Props> = ({ values }: Props) => {
           labelText="Program"
           placeholder="e.g. Computer Science, Biology"
           value={values.program}
+          readOnly={readOnly}
           required
         />
         <TextInput
@@ -78,32 +83,42 @@ const BasicInfo: FC<Props> = ({ values }: Props) => {
           value={values.academicYear}
           regexMatch={/^[1-5][A-B]$/}
           errorMessage="Please enter a valid academic year (e.g. 2A, 4B)"
+          readOnly={readOnly}
           required
         />
-        <div>
-          <label id="resume">
-            Resume (PDF) <span className="text-pink-500">*</span>
-          </label>
-          <br className="md:block hidden" />
-          <input
-            id="resume"
-            type="file"
-            name="resume"
-            required
-            className="mt-2"
-            onChange={(e) => {
-              if (e.currentTarget.files) {
-                formikProps.setFieldValue("resume", e.currentTarget.files[0]);
-              }
-            }}
-          />
-        </div>
-        <br className="md:block hidden" />
+        {!readOnly && (
+          <>
+            <div>
+              <label id="resume">
+                Resume (PDF) <span className="text-pink-500">*</span>
+              </label>
+              <br className="md:block hidden" />
+              <input
+                id="resume"
+                type="file"
+                name="resume"
+                required
+                className="mt-2"
+                onChange={(e) => {
+                  if (e.currentTarget.files) {
+                    formikProps.setFieldValue(
+                      "resume",
+                      e.currentTarget.files[0],
+                    );
+                  }
+                }}
+              />
+            </div>
+
+            <br className="md:block hidden" />
+          </>
+        )}
         <SelectInput
           id="heardFrom"
           labelText="Where did you hear about us?"
           value={values.heardFrom}
           required
+          readOnly={readOnly}
           options={SELECT_SOURCES}
         />
         <br className="md:block hidden" />
@@ -112,6 +127,7 @@ const BasicInfo: FC<Props> = ({ values }: Props) => {
           labelText="How many times have you applied to Blueprint in the past?"
           value={values.timesApplied}
           required
+          readOnly={readOnly}
           options={SELECT_APPNUM}
         />
         <br className="md:block hidden" />
@@ -120,6 +136,7 @@ const BasicInfo: FC<Props> = ({ values }: Props) => {
           labelText="What are your preferred pronouns?"
           value={values.pronouns}
           options={SELECT_PRONOUNS}
+          readOnly={readOnly}
           required={false}
         />
         {values.pronouns === SELECT_PRONOUNS[3] && (
@@ -129,6 +146,7 @@ const BasicInfo: FC<Props> = ({ values }: Props) => {
                 id="pronounsSpecified"
                 labelText="Please Specify"
                 value={values.pronounsSpecified}
+                readOnly={readOnly}
               />
             </div>
           </>
@@ -142,17 +160,31 @@ const BasicInfo: FC<Props> = ({ values }: Props) => {
             <span className="text-pink-500">*</span>
           </label>
           <br className="md:block hidden" />
-          <div className="flex flex-row space-x-24 mt-4">
-            <label>
-              <Field type="radio" name="academicOrCoop" value="Academic" />
-              &nbsp;Academic
-            </label>
-            <span></span>
-            <label>
-              <Field type="radio" name="academicOrCoop" value="Co-op" />
-              &nbsp;Co-op
-            </label>
-          </div>
+          {readOnly ? (
+            values.academicOrCoop
+          ) : (
+            <div className="flex flex-row space-x-24 mt-4">
+              <label>
+                <Field
+                  type="radio"
+                  name="academicOrCoop"
+                  value="Academic"
+                  id="Academic"
+                />
+                &nbsp;Academic
+              </label>
+              <span></span>
+              <label>
+                <Field
+                  type="radio"
+                  name="academicOrCoop"
+                  value="Co-op"
+                  id="Co-op"
+                />
+                &nbsp;Co-op
+              </label>
+            </div>
+          )}
         </div>
         <br className="md:block hidden" />
         <SelectInput
@@ -160,6 +192,7 @@ const BasicInfo: FC<Props> = ({ values }: Props) => {
           labelText="What is your preferred working location?"
           value={values.locationPreference}
           options={WORKING_LOCATIONS}
+          readOnly={readOnly}
           required={true}
         />
       </div>

--- a/components/apply/BasicInfo.tsx
+++ b/components/apply/BasicInfo.tsx
@@ -161,7 +161,9 @@ const BasicInfo: FC<Props> = ({ values, readOnly }: Props) => {
           </label>
           <br className="md:block hidden" />
           {readOnly ? (
-            values.academicOrCoop
+            <div className="text-charcoal-500 mt-2">
+              {values.academicOrCoop}
+            </div>
           ) : (
             <div className="flex flex-row space-x-24 mt-4">
               <label>


### PR DESCRIPTION
<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- Added option to make Basic Info section read only

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. Checkout this branch
2. Run `yarn dev`
3. Set `readOnly` prop as `true` for `BasicInfo` and add in some dummy info for the `values` prop
4. Go to `http://localhost:3000/apply`
5. Check that all sections are read only and you cannot see the resume upload button

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

- You should not be able to see a resume upload option when `BasicInfo` is read only
- For which term the applicant is on, for read only you should see either the text "Academic" or "Co-op" printed under this section

### Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] I have run the linter
- [x] I have requested a review from other devs who have background knowledge on this PR or who will be building on top of this PR
