### PR TITLE
Add Read-only to Position Preference Components

### DIFF
--- a/components/apply/AppForm.tsx
+++ b/components/apply/AppForm.tsx
@@ -219,6 +219,7 @@ const AppForm: FC<Props> = ({
             <PositionPreference
               values={values}
               memberRoles={roleSpecificQuestions.map(({ role }) => role)}
+              readOnly={readOnly}
             />
             <ShortAnswers
               values={values}

--- a/components/apply/PositionPreference.tsx
+++ b/components/apply/PositionPreference.tsx
@@ -50,7 +50,7 @@ const PositionPreference: FC<Props> = ({
           required
           readOnly={readOnly}
         />
-        {values.firstChoiceRole != "" && (
+        {(!readOnly || values.secondChoiceRole != "") && (
           <SelectInput
             id="secondChoiceRole"
             labelText="Optional: What is your second choice role? (only select if you want to be considered for this role)"

--- a/components/apply/PositionPreference.tsx
+++ b/components/apply/PositionPreference.tsx
@@ -6,9 +6,14 @@ import { useFormikContext } from "formik";
 type Props = {
   values: AppFormValues;
   memberRoles: string[];
+  readOnly: boolean;
 };
 
-const PositionPreference: FC<Props> = ({ values, memberRoles }: Props) => {
+const PositionPreference: FC<Props> = ({
+  values,
+  memberRoles,
+  readOnly,
+}: Props) => {
   const [secondChoiceRoles, setSecondChoiceRoles] = useState(
     memberRoles.filter((roles) => roles !== values.firstChoiceRole),
   );
@@ -31,9 +36,11 @@ const PositionPreference: FC<Props> = ({ values, memberRoles }: Props) => {
   return (
     <div className="grid gap-3 mb-12">
       <h4 className="text-blue-100">Position Preference</h4>
-      <p className="text-charcoal-500 mb-4">
-        Please select the position(s) you are interested in.*
-      </p>
+      {!readOnly && (
+        <p className="text-charcoal-500 mb-4">
+          Please select the position(s) you are interested in.*
+        </p>
+      )}
       <div className="grid gap-6">
         <SelectInput
           id="firstChoiceRole"
@@ -41,14 +48,18 @@ const PositionPreference: FC<Props> = ({ values, memberRoles }: Props) => {
           value={values.firstChoiceRole}
           options={memberRoles}
           required
+          readOnly={readOnly}
         />
-        <SelectInput
-          id="secondChoiceRole"
-          labelText="Optional: What is your second choice role? (only select if you want to be considered for this role)"
-          value={values.secondChoiceRole}
-          options={secondChoiceRoles}
-          required={false}
-        />
+        {values.firstChoiceRole != "" && (
+          <SelectInput
+            id="secondChoiceRole"
+            labelText="Optional: What is your second choice role? (only select if you want to be considered for this role)"
+            value={values.secondChoiceRole}
+            options={secondChoiceRoles}
+            required={false}
+            readOnly={readOnly}
+          />
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- Added read-only prop to Position Preference Component
- Hide second-choice role question if user did not select a first choice role

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. Checkout this branch
2. Run yarn dev
3. Set readOnly prop as true for Position Preference 
4. Go to http://localhost:3000/apply
5. Check that all sections are read only and you cannot see the select choice role button

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

- You should not be able to see a select choice role select when Position Preference is read only
- You should not see the second-choice role select if the first-choice role has not been chosen

### Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] I have run the linter
- [x] I have requested a review from other devs who have background knowledge on this PR or who will be building on top of this PR
