### PR TITLE
[bugfix]: Only show applications which fell during the application window

### DIFF
--- a/components/apply/AppForm.tsx
+++ b/components/apply/AppForm.tsx
@@ -2,7 +2,7 @@ import { FC, useState } from "react";
 import { v4 as uuidv4 } from "uuid";
 import { Formik, Form } from "formik";
 import { getDownloadURL, ref as storeRef, uploadBytes } from "firebase/storage";
-import { set, ref as dbRef } from "firebase/database";
+import { set, ref as dbRef, serverTimestamp } from "firebase/database";
 
 import BasicInfo from "./BasicInfo";
 import PositionPreference from "./PositionPreference";
@@ -178,7 +178,7 @@ const AppForm: FC<Props> = ({
           secondChoiceRole: values.secondChoiceRole || "",
           shortAnswerQuestions: values.shortAnswerQuestions,
           roleSpecificQuestions: values.roleSpecificQuestions,
-          timestamp: Date.now(),
+          timestamp: serverTimestamp(),
           status: "pending",
         };
 


### PR DESCRIPTION
<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

This is to get around the fact that people can change their system time
to avoid the deadline/submit before apps open.

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. Using a locally set-up environment, change your system time into the current BP app window.
2. Submit an application.
3. Visit the admin page and verify your application DOES NOT show up there.

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

-

### Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] I have run the linter
- [x] I have requested a review from other devs who have background knowledge on this PR or who will be building on top of this PR
