### PR TITLE
Remove "preference" from pronoun selection.

### DIFF
--- a/components/apply/BasicInfo.tsx
+++ b/components/apply/BasicInfo.tsx
@@ -134,7 +134,7 @@ const BasicInfo: FC<Props> = ({ values, readOnly }: Props) => {
         <br className="md:block hidden" />
         <SelectInput
           id="pronouns"
-          labelText="What are your preferred pronouns?"
+          labelText="What are your pronouns?"
           value={values.pronouns}
           options={SELECT_PRONOUNS}
           readOnly={readOnly}


### PR DESCRIPTION
Following up on feedback from Blueprint's content writer this term, we're removing the term "preferred pronouns" in favour of just "pronouns".    