### PR TITLE
made review PFSG and TP page dynamic

### DIFF
--- a/components/review/stages/reviewPassionForSocialGoodStage.tsx
+++ b/components/review/stages/reviewPassionForSocialGoodStage.tsx
@@ -2,35 +2,77 @@ import { ReviewStage } from "pages/review";
 import { ReviewRatingPage } from "../shared/reviewRatingPage";
 import { ReviewRubric } from "./reviewRubric";
 import { ReviewAnswers } from "./reviewAnswers";
+import { queries } from "graphql/queries";
+import { useRouter } from "next/router";
+import { FC, useState, useEffect } from "react";
+import { fetchGraphql } from "@utils/makegqlrequest";
+import { ApplicationDTO } from "types";
 
 interface Props {
   scores: Map<ReviewStage, number>;
 }
 
 const reviewPFSGScoringCriteria = [
-  "Does not provide a relevant cause that resonates with them. Example: I'm really involved in social good causes, I'm a very emphathetic person so I tend to resonate with them when I come across something negative in the world",
-  "Does not provide a relevant cause that resonates with them. Example: I'm really involved in social good causes, I'm a very emphathetic person so I tend to resonate with them when I come across something negative in the world",
-  "Does not provide a relevant cause that resonates with them. Example: I'm really involved in social good causes, I'm a very emphathetic person so I tend to resonate with them when I come across something negative in the world",
-  "Does not provide a relevant cause that resonates with them. Example: I'm really involved in social good causes, I'm a very emphathetic person so I tend to resonate with them when I come across something negative in the world",
-  "Does not provide a relevant cause that resonates with them. Example: I'm really involved in social good causes, I'm a very emphathetic person so I tend to resonate with them when I come across something negative in the world",
+  "Does not provide a relevant cause that resonates with them. Example: I'm really involved in social good causes, I'm a very empathetic person so I tend to resonate with them when I come across something negative in the world",
+  "Provides a superficial and/or shallow reason for why a cause resonates with them or picks a generic cause with a generic reason or personal connection is vague. Example: I resonate with social isolation in long term care homes. I hear a lot about it from my family members and it was an assigned topic at a case competition that I went to etc",
+  "Provides a reason as to why that cause resonates with them and demonstrates genuine passion and enthusiasm for said cause. Connects to the cause on a personal level. Example: Access to education is a cause that resonates with me because I grew up in [x] and I saw first hand how lack of education can [...]. ",
+  "Provides a meaningful reason as to why that cause resonates with them and demonstrates genuine passion and enthusiasm for said cause. Backs up their passion with specific examples of action taken whether that be volunteer work, demonstrating in depth research, etc. Bonus: References a Blueprint project/did research. Example: Access to education is a cause that resonates with me because I grew up in [x] and I saw first hand how lack of education can [...]. Recognizing my own privilege to receive education in Canada, I [.action/research..] etc",
 ];
 
-const sampleQuestions = [
-  "Tell us about a time you learned a new skill. What was your motivation to learn it and what was your approach?",
-  "Bonus: Tell us about a cause that resonates with you",
-];
+interface AuthStatus {
+  loading: boolean;
+  isAuthorized: boolean;
+}
 
-const sampleAnswers = [
-  "The organization I'm volunteering for right now, IleTTonna, is a healthcare startup devoted to helping those struggling through the postpartum period. To be completely honest, it's mission didn't resonate with me as much as it does now than when I first started. At the beginning, I wasn't sure how helpful what we were doing was because our audience seemed to sniche. But now, after meeting with stakeholders and launching our MVP, we're getting a lot of responses. Seeing the impact of your work is incredible and does a lot to inspire more hard work. ",
-  "The organization I'm volunteering for right now, IleTTonna, is a healthcare startup devoted to helping those struggling through the postpartum period. To be completely honest, it's mission didn't resonate with me as much as it does now than when I first started. At the beginning, I wasn't sure how helpful what we were doing was because our audience seemed to sniche. But now, after meeting with stakeholders and launching our MVP, we're getting a lot of responses. Seeing the impact of your work is incredible and does a lot to inspire more hard work. ",
-];
+interface Props {
+  scores: Map<ReviewStage, number>;
+  reviewId: number;
+}
 
-export const ReviewPassionForSocialGoodStage: React.FC<Props> = ({
-  scores,
-}) => {
+export const ReviewPassionForSocialGoodStage: React.FC<Props> = ({ scores, reviewId }) => {
+  const router = useRouter();
+  const [name, setName] = useState("");
+  const [questions, setQuestions] = useState<string[]>([]);
+  const [answers, setAnswers] = useState<string[]>([]);
+  const [authStatus, setAuthStatus] = useState<AuthStatus>({
+    loading: true,
+    isAuthorized: false,
+  });
+  useEffect(() => {
+    fetchGraphql(queries.applicationsById, {
+      id: reviewId,
+    }).then((result) => {
+      if (result.data) {
+        const appInfo: ApplicationDTO = result.data.applicationsById;
+        const shortAnswerStr = appInfo.shortAnswerQuestions[0];
+        const shortAnswerJSON = JSON.parse(shortAnswerStr);
+        const combinedName = appInfo.firstName + " " + appInfo.lastName;
+        setName(combinedName);
+
+        const extractedQuestions = shortAnswerJSON.map(
+          (dict: { [key: string]: string }) => {
+            return dict.question;
+          },
+        );
+
+        const extractedAnswers = shortAnswerJSON.map(
+          (dict: { [key: string]: string }) => {
+            return dict.response;
+          },
+        );
+        setQuestions((questions) => [...questions, extractedQuestions[1]]);
+        setAnswers((answers) => [...answers, extractedAnswers[1]]);
+      } else {
+        setAuthStatus({
+          loading: false,
+          isAuthorized: false,
+        });
+      }
+    });
+  }, []);
   return (
     <ReviewRatingPage
-      studentName="M. Goose"
+      studentName= {name}
       title="Passion for social good"
       currentStage={ReviewStage.PFSG}
       currentStageRubric={
@@ -41,7 +83,7 @@ export const ReviewPassionForSocialGoodStage: React.FC<Props> = ({
         />
       }
       currentStageAnswers={
-        <ReviewAnswers questions={sampleQuestions} answers={sampleAnswers} />
+        <ReviewAnswers questions={questions} answers={answers} />
       }
       scores={scores}
     />

--- a/components/review/stages/reviewTeamPlayerStage.tsx
+++ b/components/review/stages/reviewTeamPlayerStage.tsx
@@ -2,33 +2,78 @@ import { ReviewStage } from "pages/review";
 import { ReviewRatingPage } from "../shared/reviewRatingPage";
 import { ReviewRubric } from "./reviewRubric";
 import { ReviewAnswers } from "./reviewAnswers";
+import { queries } from "graphql/queries";
+import { useRouter } from "next/router";
+import { FC, useState, useEffect } from "react";
+import { fetchGraphql } from "@utils/makegqlrequest";
+import { ApplicationDTO } from "types";
 
 interface Props {
   scores: Map<ReviewStage, number>;
 }
 
 const reviewTPScoringCriteria = [
-  "Does not provide a relevant cause that resonates with them. Example: I'm really involved in social good causes, I'm a very emphathetic person so I tend to resonate with them when I come across something negative in the world",
-  "Does not provide a relevant cause that resonates with them. Example: I'm really involved in social good causes, I'm a very emphathetic person so I tend to resonate with them when I come across something negative in the world",
-  "Does not provide a relevant cause that resonates with them. Example: I'm really involved in social good causes, I'm a very emphathetic person so I tend to resonate with them when I come across something negative in the world",
-  "Does not provide a relevant cause that resonates with them. Example: I'm really involved in social good causes, I'm a very emphathetic person so I tend to resonate with them when I come across something negative in the world",
-  "Does not provide a relevant cause that resonates with them. Example: I'm really involved in social good causes, I'm a very emphathetic person so I tend to resonate with them when I come across something negative in the world",
+  "Provides an irrelevant example of a meaningful community. Example has zero personal connection. Example: UW Blueprint seems to be a great community and I'd be proud to be a part of it",
+  "Only talks about the community but doesn't mention any contributions made or doesn't indicate why the community is meaningful to the candidate; doesn't have a personal connection. No mention is made of collaboration or group impacts. Example: I'm a part of [x] and I met a lot of great people through it!",
+  "Personal and meaningful connection to the community is evident and demonstrates strong contributions to the community. Speaks of the community and its impacts and the candidates impacts on the community with genuine passion. Example: I'm proud to be a part of [x] community because of [x, y, z]. I do [x] for the community by doing [y] because this community [...], etc.",
+  "Personal and meaningful connection to the community is evident and demonstrates going above and beyond to contribute to that community. Genuinely talks about collaboration and the impact either the candidate had on the community and/or the impact of the community on the candidate. Example: I have been a part of [x] community for [x] years. It has taught me [x, y, z]. In this community I do [x]. As a result I was able to help the community do [x, y, z], etc.", 
 ];
 
-const sampleQuestions = [
-  "Tell us about a time you learned a new skill. What was your motivation to learn it and what was your approach?",
-  "Bonus: Tell us about a cause that resonates with you",
-];
+interface AuthStatus {
+  loading: boolean;
+  isAuthorized: boolean;
+}
 
-const sampleAnswers = [
-  "The organization I'm volunteering for right now, IleTTonna, is a healthcare startup devoted to helping those struggling through the postpartum period. To be completely honest, it's mission didn't resonate with me as much as it does now than when I first started. At the beginning, I wasn't sure how helpful what we were doing was because our audience seemed to sniche. But now, after meeting with stakeholders and launching our MVP, we're getting a lot of responses. Seeing the impact of your work is incredible and does a lot to inspire more hard work. ",
-  "The organization I'm volunteering for right now, IleTTonna, is a healthcare startup devoted to helping those struggling through the postpartum period. To be completely honest, it's mission didn't resonate with me as much as it does now than when I first started. At the beginning, I wasn't sure how helpful what we were doing was because our audience seemed to sniche. But now, after meeting with stakeholders and launching our MVP, we're getting a lot of responses. Seeing the impact of your work is incredible and does a lot to inspire more hard work. ",
-];
+interface Props {
+  scores: Map<ReviewStage, number>;
+  reviewId: number;
+}
 
-export const ReviewTeamPlayerStage: React.FC<Props> = ({ scores }) => {
+
+export const ReviewTeamPlayerStage: React.FC<Props> = ({ scores, reviewId }) => {
+  const router = useRouter();
+  const [name, setName] = useState("");
+  const [questions, setQuestions] = useState<string[]>([]);
+  const [answers, setAnswers] = useState<string[]>([]);
+  const [authStatus, setAuthStatus] = useState<AuthStatus>({
+    loading: true,
+    isAuthorized: false,
+  });
+  useEffect(() => {
+    fetchGraphql(queries.applicationsById, {
+      id: reviewId,
+    }).then((result) => {
+      if (result.data) {
+        const appInfo: ApplicationDTO = result.data.applicationsById;
+        const shortAnswerStr = appInfo.shortAnswerQuestions[0];
+        const shortAnswerJSON = JSON.parse(shortAnswerStr);
+        const combinedName = appInfo.firstName + " " + appInfo.lastName;
+        setName(combinedName);
+
+        const extractedQuestions = shortAnswerJSON.map(
+          (dict: { [key: string]: string }) => {
+            return dict.question;
+          },
+        );
+
+        const extractedAnswers = shortAnswerJSON.map(
+          (dict: { [key: string]: string }) => {
+            return dict.response;
+          },
+        );
+        setQuestions((questions) => [...questions, extractedQuestions[2]]);
+        setAnswers((answers) => [...answers, extractedAnswers[2]]);
+      } else {
+        setAuthStatus({
+          loading: false,
+          isAuthorized: false,
+        });
+      }
+    });
+  }, []);
   return (
     <ReviewRatingPage
-      studentName="M. Goose"
+      studentName= {name}
       title="Team player"
       currentStage={ReviewStage.TP}
       currentStageRubric={
@@ -39,7 +84,7 @@ export const ReviewTeamPlayerStage: React.FC<Props> = ({ scores }) => {
         />
       }
       currentStageAnswers={
-        <ReviewAnswers questions={sampleQuestions} answers={sampleAnswers} />
+        <ReviewAnswers questions={questions} answers={answers} />
       }
       scores={scores}
     />

--- a/pages/review/index.tsx
+++ b/pages/review/index.tsx
@@ -64,9 +64,9 @@ const ReviewsPages: NextPage = () => {
       case ReviewStage.INFO:
         return <ReviewInfoStage scores={scores} reviewId={reviewId} />;
       case ReviewStage.PFSG:
-        return <ReviewPassionForSocialGoodStage scores={scores} />;
+        return <ReviewPassionForSocialGoodStage scores={scores} reviewId={reviewId} />;
       case ReviewStage.TP:
-        return <ReviewTeamPlayerStage scores={scores} />;
+        return <ReviewTeamPlayerStage scores={scores} reviewId={reviewId}/>;
       case ReviewStage.D2L:
         return <ReviewDriveToLearnStage scores={scores} />;
       case ReviewStage.SKL:


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Review Page - PFSG Page](https://www.notion.so/uwblueprintexecs/Review-Page-PFSG-Page-a57bbb10d71a435483e08efe8dd7870d)

[Review Page - TP Page](https://www.notion.so/uwblueprintexecs/Review-Page-TP-Page-ff269be807b64909ae929233ae770996)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Made Passions for Social Good and TeamPlayer marking page dynamic by utilizing applicationbyid query to retrieve required information. 
 
<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Go to http://localhost:3000/review?reviewId=1 after launching website and applicant's responses should show up for TP and PFSG page! 


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Please focus on the formatting of rubric and how examples for each level (1 to 4) should show up. Right now I have it as: 
(Explanation of level 1). Example: (example of level 1 response) 
* Do we want examples of each level on a new line? or formatted some other way? 
* Lucy has mentioned we may not have correct rubric content, may need to update once verified. Right now I referred to this doc for the content: https://docs.google.com/document/d/112YpW3vCWesRxu6tzt-ZqubZvJy2zIUVLdbjTjuEB4U/edit

## Checklist
- [X] My PR name is descriptive and in imperative tense
- [X] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [?] I have run the appropriate linter(s)
- [X] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
