### PR TITLE
Add /build campaign landing page

### DIFF
--- a/src/app/build/page.tsx
+++ b/src/app/build/page.tsx
@@ -1,0 +1,29 @@
+import type { Metadata } from "next";
+
+import { ApplicationsCountdown } from "@/components/sections/ApplicationsCountdown";
+import { BuildHero } from "@/components/sections/BuildHero";
+import { ImpactStatement } from "@/components/sections/ImpactStatement";
+import { RolesCTA } from "@/components/sections/RolesCTA";
+import { TeamPhotos } from "@/components/sections/TeamPhotos";
+import { WhatWeLookFor } from "@/components/sections/WhatWeLookFor";
+import { WhyJoin } from "@/components/sections/WhyJoin";
+
+export const metadata: Metadata = {
+  title: "Build real things",
+  description:
+    "Tired of building fake things? Come build real things with us at UW Blueprint. Applications open July 1, 2026.",
+};
+
+export default function BuildPage() {
+  return (
+    <main>
+      <BuildHero />
+      <ImpactStatement />
+      <WhyJoin />
+      <TeamPhotos />
+      <WhatWeLookFor />
+      <RolesCTA />
+      <ApplicationsCountdown />
+    </main>
+  );
+}

--- a/src/components/sections/ApplicationsCountdown.tsx
+++ b/src/components/sections/ApplicationsCountdown.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { FadeUp } from "@/components/ui/FadeUp";
+import { Button } from "@/components/ui/Button";
+import { cn } from "@/lib/utils";
+
+// Applications open July 1, 2026 at 12:00 AM (America/Toronto, UTC-4 in July).
+const APPLICATIONS_OPEN = new Date("2026-07-01T00:00:00-04:00");
+
+// Application window: July 1 – July 10, 2026.
+const APPLY_BY = new Date("2026-07-10T23:59:00-04:00");
+
+type TimeLeft = {
+  days: number;
+  hours: number;
+  minutes: number;
+  seconds: number;
+  isOpen: boolean;
+};
+
+function getTimeLeft(): TimeLeft {
+  const diff = APPLICATIONS_OPEN.getTime() - Date.now();
+  if (diff <= 0) {
+    return { days: 0, hours: 0, minutes: 0, seconds: 0, isOpen: true };
+  }
+  const totalSeconds = Math.floor(diff / 1000);
+  return {
+    days: Math.floor(totalSeconds / 86400),
+    hours: Math.floor((totalSeconds % 86400) / 3600),
+    minutes: Math.floor((totalSeconds % 3600) / 60),
+    seconds: totalSeconds % 60,
+    isOpen: false,
+  };
+}
+
+// Format a Date as an iCalendar UTC timestamp: YYYYMMDDTHHMMSSZ
+function toICalUTC(date: Date): string {
+  return date
+    .toISOString()
+    .replace(/[-:]/g, "")
+    .replace(/\.\d{3}/, "");
+}
+
+function downloadCalendarInvite() {
+  const ics = [
+    "BEGIN:VCALENDAR",
+    "VERSION:2.0",
+    "PRODID:-//UW Blueprint//Applications//EN",
+    "CALSCALE:GREGORIAN",
+    "METHOD:PUBLISH",
+    "BEGIN:VEVENT",
+    "UID:applications-2026-summer@uwblueprint.org",
+    `DTSTAMP:${toICalUTC(new Date())}`,
+    `DTSTART:${toICalUTC(APPLICATIONS_OPEN)}`,
+    `DTEND:${toICalUTC(APPLY_BY)}`,
+    "SUMMARY:Apply to UW Blueprint",
+    "DESCRIPTION:Applications to join UW Blueprint are open from July 1 to July 10\\, 2026. Come build real things with us! Apply at https://uwblueprint.org/build",
+    "URL:https://uwblueprint.org/build",
+    "BEGIN:VALARM",
+    "TRIGGER:-PT0M",
+    "ACTION:DISPLAY",
+    "DESCRIPTION:Applications to UW Blueprint are now open",
+    "END:VALARM",
+    "END:VEVENT",
+    "END:VCALENDAR",
+  ].join("\r\n");
+
+  const blob = new Blob([ics], { type: "text/calendar;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = "uw-blueprint-applications.ics";
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}
+
+const UNITS: { key: keyof Omit<TimeLeft, "isOpen">; label: string }[] = [
+  { key: "days", label: "days" },
+  { key: "hours", label: "hours" },
+  { key: "minutes", label: "minutes" },
+  { key: "seconds", label: "seconds" },
+];
+
+export function ApplicationsCountdown({ className }: { className?: string }) {
+  const [timeLeft, setTimeLeft] = useState<TimeLeft | null>(null);
+
+  useEffect(() => {
+    setTimeLeft(getTimeLeft());
+    const interval = setInterval(() => setTimeLeft(getTimeLeft()), 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const isOpen = timeLeft?.isOpen ?? false;
+
+  return (
+    <section
+      aria-label="Applications countdown"
+      className={cn("bg-[#121D5D] px-8 py-8 md:py-24 text-left", className)}
+    >
+      <FadeUp inView>
+        <div className="grid w-full grid-cols-12 gap-0">
+          <h2
+            lang="en"
+            className="col-span-12 max-w-3xl text-lg text-[var(--primary-light)] [hyphens:auto] break-words pb-10"
+          >
+            {isOpen
+              ? "Applications are open until July 10th"
+              : "Applications open on July 1st"}
+          </h2>
+
+          {!isOpen && (
+            <div
+              className="col-span-12 flex flex-wrap gap-x-8 gap-y-6 pb-12"
+              aria-live="polite"
+            >
+              {UNITS.map(({ key, label }) => (
+                <div key={key} className="flex flex-col">
+                  <span
+                    className="text-xl text-[var(--primary-light)] tabular-nums"
+                    style={{ lineHeight: 0.9 }}
+                  >
+                    {timeLeft ? String(timeLeft[key]).padStart(2, "0") : "--"}
+                  </span>
+                  <span className="text-md lowercase text-[var(--secondary-light)]">
+                    {label}
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+
+          <div className="col-span-12">
+            <Button
+              type="button"
+              variant="filled-light"
+              size="md"
+              className="text-[#121D5D]"
+              onClick={downloadCalendarInvite}
+            >
+              save to calendar
+            </Button>
+          </div>
+        </div>
+      </FadeUp>
+    </section>
+  );
+}

--- a/src/components/sections/BuildHero.tsx
+++ b/src/components/sections/BuildHero.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+export function BuildHero() {
+  return (
+    <section
+      aria-label="Build real things hero"
+      className="flex h-[75vh] flex-col justify-end overflow-hidden bg-[var(--bp-blue)]"
+    >
+      <div className="grid w-full grid-cols-12 gap-0 px-8 pb-8">
+        <div className="col-span-12 flex flex-col gap-4 md:gap-16">
+          <h1 className="text-xxl lowercase text-[var(--primary-light)] leading-[0.88] md:leading-[0.8]">
+            tired of building
+            <br />
+            fake things?
+          </h1>
+
+          <div className="flex max-w-3xl flex-col gap-1.5 text-lg">
+            <p className="text-[var(--primary-light)]">
+              Come build real things with us at Blueprint. Applications open
+              July 1st.
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/sections/ImpactStatement.tsx
+++ b/src/components/sections/ImpactStatement.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { FadeUp } from "@/components/ui/FadeUp";
+import { cn } from "@/lib/utils";
+
+export function ImpactStatement({ className }: { className?: string }) {
+  return (
+    <section
+      aria-label="Our impact"
+      className={cn("bg-[#F2F2F2] px-8 py-8 md:py-24", className)}
+    >
+      <FadeUp inView>
+        <p className="max-w-3xl text-lg text-[var(--primary-dark)]">
+          <span className="text-[var(--bp-blue)]">
+            Our software makes an impact.
+          </span>{" "}
+          One shelter management portal means a roof over a thousand more heads.
+          One routing algorithm means food reaches hundreds more children. And
+          that&apos;s enough reason to build something great.
+        </p>
+      </FadeUp>
+    </section>
+  );
+}

--- a/src/components/sections/RolesCTA.tsx
+++ b/src/components/sections/RolesCTA.tsx
@@ -6,8 +6,7 @@ import { FadeUp } from "@/components/ui/FadeUp";
 import { buttonVariants } from "@/components/ui/button-variants";
 import { cn } from "@/lib/utils";
 
-const ROLES_NOTION_LINK =
-  "https://uwblueprintexecs.notion.site/Role-Responsibilities-9494c8311ce0471f997c7473e0bfea1c";
+const ROLES_LINK = "/roles";
 
 export function RolesCTA({ className }: { className?: string }) {
   return (
@@ -33,9 +32,7 @@ export function RolesCTA({ className }: { className?: string }) {
 
           <div className="col-span-12">
             <Link
-              href={ROLES_NOTION_LINK}
-              target="_blank"
-              rel="noopener noreferrer"
+              href={ROLES_LINK}
               className={buttonVariants({ variant: "filled-blue", size: "md" })}
             >
               learn more about the roles

--- a/src/components/sections/RolesCTA.tsx
+++ b/src/components/sections/RolesCTA.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import Link from "next/link";
+
+import { FadeUp } from "@/components/ui/FadeUp";
+import { buttonVariants } from "@/components/ui/button-variants";
+import { cn } from "@/lib/utils";
+
+const ROLES_NOTION_LINK =
+  "https://uwblueprintexecs.notion.site/Role-Responsibilities-9494c8311ce0471f997c7473e0bfea1c";
+
+export function RolesCTA({ className }: { className?: string }) {
+  return (
+    <section
+      aria-label="Learn more about the roles at Blueprint"
+      className={cn(
+        "bg-[var(--primary-light)] px-8 pt-8 pb-8 md:pt-24 text-left",
+        className,
+      )}
+    >
+      <FadeUp inView>
+        <div className="grid w-full grid-cols-12 gap-0">
+          <h2 className="col-span-12 text-xxl lowercase text-[var(--bp-blue)] leading-[1.1] md:leading-none pb-8">
+            our roles
+          </h2>
+
+          <p className="col-span-12 max-w-3xl text-md pb-12 text-[var(--secondary-dark)] min-[800px]:col-span-8">
+            From developers and designers to product managers and finance,
+            there&apos;s a place for you no matter your year or experience. We
+            assess every applicant on their drive to learn, cultural fit, and
+            passion for social good.
+          </p>
+
+          <div className="col-span-12">
+            <Link
+              href={ROLES_NOTION_LINK}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={buttonVariants({ variant: "filled-blue", size: "md" })}
+            >
+              learn more about the roles
+            </Link>
+          </div>
+        </div>
+      </FadeUp>
+    </section>
+  );
+}

--- a/src/components/sections/WhatWeLookFor.tsx
+++ b/src/components/sections/WhatWeLookFor.tsx
@@ -31,17 +31,17 @@ export function WhatWeLookFor({ className }: { className?: string }) {
     <section
       id="what-we-look-for"
       aria-label="What we look for"
-      className={cn("bg-[var(--bp-blue)] px-8 pt-24 pb-8", className)}
+      className={cn("bg-[var(--bp-blue)] px-8 pt-8 pb-8 md:pt-24", className)}
     >
-      <h2 className="text-xxl lowercase text-[var(--primary-light)] pb-8 md:pb-48">
+      <h2 className="text-xxl lowercase text-[var(--primary-light)] leading-[1.1] md:leading-none pb-8 md:pb-48">
         what we look for
       </h2>
 
-      <div className="grid grid-cols-1 min-[800px]:grid-cols-4 min-[800px]:auto-rows-fr gap-0">
+      <div className="grid grid-cols-1 gap-y-8 min-[800px]:grid-cols-4 min-[800px]:auto-rows-fr min-[800px]:gap-0">
         {TRAITS.map((trait, i) => (
           <FadeUp key={trait.title} index={i} inView>
             <div className="h-full">
-              <div className="flex h-full flex-col  md:p-6 transition-colors duration-200 hover:bg-white/5">
+              <div className="flex h-full flex-col p-0 transition-colors duration-200 min-[800px]:p-6 min-[800px]:hover:bg-white/5">
                 <h3 className="pb-4 text-lg text-[var(--primary-light)]">
                   {trait.title}
                 </h3>

--- a/src/components/sections/WhyJoin.tsx
+++ b/src/components/sections/WhyJoin.tsx
@@ -26,14 +26,17 @@ export function WhyJoin({ className }: { className?: string }) {
     <section
       id="why-join"
       aria-label="Why join Blueprint"
-      className={cn("bg-[var(--primary-light)] px-8 pt-24 pb-8", className)}
+      className={cn(
+        "bg-[var(--primary-light)] px-8 pt-8 pb-8 md:pt-24",
+        className,
+      )}
     >
       <div className="grid w-full grid-cols-12 gap-0">
-        <h2 className="col-span-12 text-xxl lowercase text-[var(--bp-blue)] pb-16">
+        <h2 className="col-span-12 text-xxl lowercase text-[var(--bp-blue)] leading-[1.1] md:leading-none pb-8 md:pb-16">
           why join?
         </h2>
 
-        <div className="col-span-12 grid grid-cols-12 gap-0 min-[800px]:auto-rows-fr">
+        <div className="col-span-12 grid grid-cols-12 gap-y-8 min-[800px]:gap-0 min-[800px]:auto-rows-fr">
           {VALUE_PROPS.map((prop, i) => (
             <FadeUp
               key={prop.title}
@@ -42,7 +45,7 @@ export function WhyJoin({ className }: { className?: string }) {
               className="col-span-12 min-[800px]:col-span-4"
             >
               <div className="h-full">
-                <div className="flex h-full flex-col p-6 transition-colors duration-200 hover:bg-black/5">
+                <div className="flex h-full flex-col p-0 transition-colors duration-200 min-[800px]:p-6 min-[800px]:hover:bg-black/5">
                   <h3 className="pb-4 text-lg text-[var(--primary-dark)]">
                     {prop.title}
                   </h3>


### PR DESCRIPTION
## Summary

Adds a standalone marketing landing page at **`/build`** for the recruitment poster campaign. It's duplicated from the **Join Our Team** page with campaign-specific copy, a new thesis statement, a roles CTA, and an applications countdown with a calendar download.

The page is intentionally **not linked in the site nav** — it's a standalone landing target for the poster.

## What's on the page (`src/app/build/page.tsx`)

1. **BuildHero** — "tired of building fake things?" hero, capped at `75vh`, subtext "Come build real things with us at Blueprint. Applications open July 1st."
2. **ImpactStatement** *(new)* — core thesis statement on a `#F2F2F2` background to differentiate it from the section below.
3. **WhyJoin** — reused as-is.
4. **TeamPhotos** — reused as-is.
5. **WhatWeLookFor** — reused as-is.
6. **RolesCTA** *(new)* — "our roles" section linking to the roles Notion page.
7. **ApplicationsCountdown** *(new)* — live countdown to **July 1, 2026 12:00 AM ET** on a `#121D5D` focus background, with a **"save to calendar"** button that downloads an `.ics` invite for the July 1–10 application window.

## Shared component changes (also affect `/join-us`)

`WhyJoin` and `WhatWeLookFor` received mobile-responsive fixes:
- Zero card padding and no hover effect on mobile (hover/padding gated to ≥800px)
- Inter-card vertical gap on mobile (`gap-y-8`)
- Section vertical padding matched to horizontal padding on mobile
- ~10% looser heading line-height on mobile

These apply to the Join Our Team page too — flagging for reviewer awareness.

## Notes
- Countdown dates/timezone are constants at the top of `ApplicationsCountdown.tsx` if they need adjusting.
- Pre-existing unrelated `tsc` error in `src/pages/admin/index.tsx` exists on `main` and is not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)