### PR TITLE
Rename Project Lead role to Technical Lead

### DIFF
--- a/constants/highlighted-projects.json
+++ b/constants/highlighted-projects.json
@@ -65,7 +65,7 @@
     "solution": "Our team built a web and iPad solution for mass-casualty incidents. The iPad component is used by paramedics in the field for patient tracking and triaging while the web component is used to view patient statuses from the command centre.",
     "quote": {
       "text": "We are extremely extremely proud of the project the team has made and super happy to have the team as a part of the project.",
-      "signature": "Stephen Yang, Project Lead and Howard Yu, Project Manager"
+      "signature": "Stephen Yang, Technical Lead and Howard Yu, Project Manager"
     },
     "image": "/projects/paramedics.png"
   },

--- a/constants/join-faq.json
+++ b/constants/join-faq.json
@@ -20,7 +20,7 @@
     },
     {
       "question": "Do I get to choose which project I work on?",
-      "answer": "Before the term begins, our designers and developers have a chance to get to know the upcoming projects. They then fill out information about their skills and preferences in our selection form so that project leads and project managers can choose their teams accordingly. We always strive to get everyone their top choices, but no guarantees can be made."
+      "answer": "Before the term begins, our designers and developers have a chance to get to know the upcoming projects. They then fill out information about their skills and preferences in our selection form so that technical leads and project managers can choose their teams accordingly. We always strive to get everyone their top choices, but no guarantees can be made."
     },
     {
       "question": "How does mentorship work in Blueprint?",

--- a/constants/role-specific-questions.json
+++ b/constants/role-specific-questions.json
@@ -82,7 +82,7 @@
   },
   {
     "id": "4",
-    "role": "Project Lead",
+    "role": "Technical Lead",
     "questions": [
       {
         "question": "Tell us about a challenging technical problem that you've worked on in the past and how you solved it.",

--- a/constants/temp-roles.json
+++ b/constants/temp-roles.json
@@ -1,17 +1,17 @@
 {
-    "id": "8",
-    "role": "VP Engineering",
-    "questions": [
-        {
-        "question": "Consider this hypothetical scenario: Blueprint is thinking of creating a standardized code repository for new projects to build off of. This idea has both supporters and detractors among the project leads. In bullet points, explain how you would build alignment among developers. Please state any assumptions or details as necessary.",
-        "maxLength": 1000
-        },
-        {
-        "uniqueid": 1,
-        "question": "Would you be interested in joining a scoping pod?",
-        "description": "Scoping pods include a designer, developer, and PM to join VP Scoping for meetings with NPO’s to provide their opinion and expertise! This will be in addition to the existing responsibilities of your role.",
-        "type": "select",
-        "options": ["Yes", "No"]
-        }
-    ]
+  "id": "8",
+  "role": "VP Engineering",
+  "questions": [
+    {
+      "question": "Consider this hypothetical scenario: Blueprint is thinking of creating a standardized code repository for new projects to build off of. This idea has both supporters and detractors among the technical leads. In bullet points, explain how you would build alignment among developers. Please state any assumptions or details as necessary.",
+      "maxLength": 1000
+    },
+    {
+      "uniqueid": 1,
+      "question": "Would you be interested in joining a scoping pod?",
+      "description": "Scoping pods include a designer, developer, and PM to join VP Scoping for meetings with NPO’s to provide their opinion and expertise! This will be in addition to the existing responsibilities of your role.",
+      "type": "select",
+      "options": ["Yes", "No"]
+    }
+  ]
 }

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -88,7 +88,7 @@ const PROJECTS = [
     ourSolution:
       "Our team built a web and iPad solution for mass-casualty incidents. The iPad component is used by paramedics in the field for patient tracking and triaging while the web component is used to view patient statuses from the command centre.",
     testimonial:
-      '"We are extremely extremely proud of the project the team has made and super happy to have the team as a part of the project." — Stephen Yang, Project Lead and Howard Yu, Project Manager',
+      '"We are extremely extremely proud of the project the team has made and super happy to have the team as a part of the project." — Stephen Yang, Technical Lead and Howard Yu, Project Manager',
   },
   {
     id: "dancefest",

--- a/src/app/roles/page.tsx
+++ b/src/app/roles/page.tsx
@@ -1,12 +1,14 @@
 import type { Metadata } from "next";
 
 import { RolesHero } from "@/components/sections/RolesHero";
-import { RolesSection, type RoleItem } from "@/components/sections/RolesSection";
+import {
+  RolesSection,
+  type RoleItem,
+} from "@/components/sections/RolesSection";
 
 export const metadata: Metadata = {
   title: "Roles | UW Blueprint",
-  description:
-    "Learn more about how we work as a team at Blueprint.",
+  description: "Learn more about how we work as a team at Blueprint.",
 };
 
 const EXECUTIVE_TEAM: RoleItem[] = [
@@ -23,11 +25,11 @@ const EXECUTIVE_TEAM: RoleItem[] = [
   {
     title: "VP Engineering",
     description:
-      "The VP Engineering is responsible for the technical success of current and future projects. They drive initiatives that improve org-wide engineering processes and foster mentorship. They lead all project leads on Blueprint.",
+      "The VP Engineering is responsible for the technical success of current and future projects. They drive initiatives that improve org-wide engineering processes and foster mentorship. They lead all technical leads on Blueprint.",
     responsibilities: [
       "Conduct architecture design reviews, provide code standards, write technical documentation.",
       "Lead engineering recruitment, and organize developer bootcamp.",
-      "Help evaluate the technical feasibility of potential NPO projects, and regularly provide advice and guidance to the project leads through 1-1s and meetings.",
+      "Help evaluate the technical feasibility of potential NPO projects, and regularly provide advice and guidance to the technical leads through 1-1s and meetings.",
     ],
     note: "Generally a senior, internal-hire preferred role.",
   },
@@ -180,9 +182,9 @@ const PROJECT_TEAM: RoleItem[] = [
     responsibilities: [
       "Write, test, and maintain code in line with the team's best practices and technical standards.",
       "Participate in code reviews, both giving and receiving feedback to improve code quality and personal growth.",
-      "Collaborate with the Project Lead and other developers to break down tasks, estimate work, and meet project milestones.",
+      "Collaborate with the Technical Lead and other developers to break down tasks, estimate work, and meet project milestones.",
       "Communicate progress, blockers, and questions proactively during team meetings and check-ins.",
-      "Continuously learn and develop technical skills, taking advantage of mentorship from the Project Lead and other senior members.",
+      "Continuously learn and develop technical skills, taking advantage of mentorship from the Technical Lead and other senior members.",
     ],
     note: "Open to all experience levels; a great opportunity to gain hands-on experience in a team setting.",
   },
@@ -227,9 +229,9 @@ const PROJECT_TEAM: RoleItem[] = [
     note: "Generally a senior, internal-hire preferred role.",
   },
   {
-    title: "Project Lead",
+    title: "Technical Lead",
     description:
-      "The Project Lead (or Technical Lead) is responsible for leading the team and driving the technical direction of the project, providing support and mentorship to developers on the team and working with the product manager to run the team effectively.",
+      "The Technical Lead is responsible for leading the team and driving the technical direction of the project, providing support and mentorship to developers on the team and working with the product manager to run the team effectively.",
     responsibilities: [
       "Organizing best code practices, performing code reviews, mentoring developers, planning tasks, making key technical decisions and software architecture design.",
       "Provide leadership, mentorship, and project execution skills as the overall success of the team is largely self guided.",
@@ -239,7 +241,7 @@ const PROJECT_TEAM: RoleItem[] = [
     ],
     link: {
       href: "https://medium.com/uw-blueprint/member-spotlight-project-lead-anne-chung-1ca9f22c9db3",
-      label: "Member Spotlight — Project Lead",
+      label: "Member Spotlight — Technical Lead",
     },
     note: "Generally a senior, internal-hire preferred role.",
   },
@@ -248,7 +250,7 @@ const PROJECT_TEAM: RoleItem[] = [
     description:
       "The Product Manager will be responsible for managing the delivery of a digital product to the NPO partner. This involves scoping features, iterating on feedback, and maintaining communications with the NPO.",
     responsibilities: [
-      "Own product definition and design execution: own feature definition from idea to delivery. Partner with designers to scope features, shape core flows, and prototype solutions. Work with the project lead (engineering manager) to evaluate trade-offs, answer product questions, and make final build decisions.",
+      "Own product definition and design execution: own feature definition from idea to delivery. Partner with designers to scope features, shape core flows, and prototype solutions. Work with the technical lead (engineering manager) to evaluate trade-offs, answer product questions, and make final build decisions.",
       "Build the client relationship and project direction: serve as the primary client lead. Run bi-weekly demos, present work, and gather feedback. Set clear expectations and guide product direction in partnership with the client.",
       "Build team culture: help create a positive and connected team environment. Build strong relationships with teammates. Host socials, bring energy to meetings, and promote a fun team culture.",
     ],
@@ -256,7 +258,7 @@ const PROJECT_TEAM: RoleItem[] = [
       href: "https://uwblueprint.medium.com/member-spotlight-sophia-zhu-pm-omhs-a-deep-dive-into-managing-tradeoffs-c56a14840ef3",
       label: "Member Spotlight — Product Manager",
     },
-    note: "PMs at Blueprint primarily work with designers and project leads (engineering managers). If you have a more eng heavy background, also consider checking out the project lead role as well.",
+    note: "PMs at Blueprint primarily work with designers and technical leads (engineering managers). If you have a more eng heavy background, also consider checking out the technical lead role as well.",
   },
 ];
 
@@ -265,10 +267,7 @@ export default function RolesPage() {
     <main className="bg-[var(--primary-light)]">
       <RolesHero />
 
-      <section
-        aria-label="Introduction"
-        className="px-8 pt-16 pb-0"
-      >
+      <section aria-label="Introduction" className="px-8 pt-16 pb-0">
         <div className="grid w-full grid-cols-12 gap-0">
           <div className="col-span-12 md:col-span-8 flex flex-col gap-4">
             <p className="text-md text-[var(--secondary-dark)]">
@@ -286,7 +285,8 @@ export default function RolesPage() {
               of the next recruitment cycle for their role.
             </p>
             <p className="text-md text-[var(--secondary-dark)]">
-              Roles only define responsibilities. Blueprint has a flat hierarchy.
+              Roles only define responsibilities. Blueprint has a flat
+              hierarchy.
             </p>
           </div>
         </div>

--- a/src/components/sections/NonprofitsFAQ.tsx
+++ b/src/components/sections/NonprofitsFAQ.tsx
@@ -18,12 +18,12 @@ const FAQ_ITEMS: FAQItem[] = [
   {
     question: "What does the nonprofit-project team interaction look like?",
     answer:
-      "Each project team is led by a pairing of project lead(s) and product manager(s) who serve as the main point of contact between the nonprofit and Blueprint. Regular check-ins include progress updates, design reviews, and feedback sessions to ensure we're building exactly what you need.",
+      "Each project team is led by a pairing of technical lead(s) and product manager(s) who serve as the main point of contact between the nonprofit and Blueprint. Regular check-ins include progress updates, design reviews, and feedback sessions to ensure we're building exactly what you need.",
   },
   {
     question: "How does UW Blueprint ensure success?",
     answer:
-      "We follow a structured development process with clearly defined milestones, regular stakeholder check-ins, and thorough quality assurance. Our scoping process helps us set realistic goals, and our experienced project leads keep teams on track throughout the term.",
+      "We follow a structured development process with clearly defined milestones, regular stakeholder check-ins, and thorough quality assurance. Our scoping process helps us set realistic goals, and our experienced technical leads keep teams on track throughout the term.",
   },
   {
     question: "What type of services does UW Blueprint provide?",

--- a/src/components/sections/WhyBlueprint.tsx
+++ b/src/components/sections/WhyBlueprint.tsx
@@ -12,7 +12,7 @@ const VALUE_PROPS = [
   {
     title: "Dedicated teams",
     description:
-      "Each nonprofit is paired with a cross-functional team of designers, developers, and a project lead who are fully invested in your success from day one.",
+      "Each nonprofit is paired with a cross-functional team of designers, developers, and a technical lead who are fully invested in your success from day one.",
   },
   {
     title: "Built to last",


### PR DESCRIPTION
## Summary

The **Project Lead** role has been renamed to **Technical Lead**. This updates every role mention across the site copy and the application forms.

## Changed

- **Application forms**: `constants/role-specific-questions.json` (`"role": "Technical Lead"`), `constants/temp-roles.json` (hypothetical question wording), `constants/join-faq.json`.
- **Roles page** (`src/app/roles/page.tsx`): the role card title/description, VP Engineering references, developer responsibilities, PM note, and the spotlight link label. Removed the now-redundant "(or Technical Lead)" parenthetical.
- **Marketing copy**: `WhyBlueprint.tsx`, `NonprofitsFAQ.tsx`, and the project testimonial signatures (`highlighted-projects.json`, `projects/page.tsx`).

## Intentionally left unchanged

- **`members.json`** — the "Project_Lead_*" strings are Firebase Storage **image filenames**; renaming would break (404) the headshots.
- **The Medium spotlight URL** in `roles/page.tsx` — a real external link (`…member-spotlight-project-lead-anne-chung…`). Only its visible label was updated.
- **`headshot-constants.ts`** — the `"technical lead": ["pl", "project lead"]` alias intentionally maps the **old** name to the new one so legacy headshot files still resolve.

`tsc` passes (aside from the pre-existing unrelated `src/pages/admin/index.tsx` error on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)